### PR TITLE
Tweak github action to fail when a step fails in deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,7 @@ jobs:
         username: grngdgtl
         host: greening.digital
         key: ${{ secrets.SSH_PRIVATE_KEY }}
+        script_stop: true
         script: |
           cd ~/ghost/content/themes/
           git clone git@github.com:Greening-Digital/greening-digital-ghost.git


### PR DESCRIPTION
Previously, when we pushed to the production branch, we'd execute the steps in `cd.yml` but if one step failed, there was no notification. This meant that the server never restarted, and cany changes were not visible.

This addition makes failures noisier, so we can diagnose.

See more here:

https://github.com/appleboy/ssh-action#input-variables